### PR TITLE
Verilog parsing based on filename

### DIFF
--- a/spydrnet/composers/__init__.py
+++ b/spydrnet/composers/__init__.py
@@ -8,5 +8,9 @@ def compose(netlist, filename):
         from spydrnet.composers.edif.composer import ComposeEdif
         composer = ComposeEdif()
         composer.run(netlist, filename)
+    elif extension_lower in [".v", ".vh"]:
+        from spydrnet.composers.verilog.composer import Composer
+        composer = Composer()
+        composer.run(netlist, file_out = filename)
     else:
         raise RuntimeError("Extension {} not recognized.".format(extension))

--- a/spydrnet/composers/verilog/tests/test_composer.py
+++ b/spydrnet/composers/verilog/tests/test_composer.py
@@ -1,7 +1,8 @@
 
 import unittest
 import spydrnet as sdn
-from spydrnet.composers.verilog.composer import Composer
+from spydrnet import composers
+from spydrnet import parsers
 import os
 import tempfile
 
@@ -17,11 +18,12 @@ class TestVerilogComposer(unittest.TestCase):
                 with tempfile.TemporaryDirectory() as tempdirectory:
                     # try:
                         print("*********************"+filename+"*********************")
-                        vp = sdn.parsers.verilog.parser.VerilogParser.from_filename(os.path.join(directory, filename))
-                        netlist = vp.parse()
-                        comp = Composer()
+                        # vp = sdn.parsers.verilog.parser.VerilogParser.from_filename(os.path.join(directory, filename))
+                        # netlist = vp.parse()
+                        netlist = parsers.parse(os.path.join(directory, filename))
+                        composers.compose(netlist, os.path.join(tempdirectory, filename[:len(filename)-6] + "-spydrnet.v"))
                         #comp.run(netlist,"temp2/"+filename[:len(filename)-6] + "-spydrnet.v")
-                        comp.run(netlist,os.path.join(tempdirectory, filename[:len(filename)-6] + "-spydrnet.v"))
+                        # comp.run(netlist,os.path.join(tempdirectory, filename[:len(filename)-6] + "-spydrnet.v"))
                         i+=1
                         print("pass")
                     # except Exception as identifier:

--- a/spydrnet/parsers/__init__.py
+++ b/spydrnet/parsers/__init__.py
@@ -25,6 +25,9 @@ def _parse(filename):
     if extension in [".edf", ".edif"]:
         from spydrnet.parsers.edif.parser import EdifParser
         parser = EdifParser.from_filename(filename)
+    elif extension in ["v", "vh"]:
+        from spydrnet.parsers.verilog.parser import VerilogParser
+        parser = VerilogParser.from_filename(filename)
     else:
         raise RuntimeError("Extension {} not recognized.".format(extension))
     parser.parse()

--- a/spydrnet/parsers/__init__.py
+++ b/spydrnet/parsers/__init__.py
@@ -25,7 +25,7 @@ def _parse(filename):
     if extension in [".edf", ".edif"]:
         from spydrnet.parsers.edif.parser import EdifParser
         parser = EdifParser.from_filename(filename)
-    elif extension in ["v", "vh"]:
+    elif extension in [".v", ".vh"]:
         from spydrnet.parsers.verilog.parser import VerilogParser
         parser = VerilogParser.from_filename(filename)
     else:

--- a/spydrnet/parsers/verilog/tests/test_verilogParser.py
+++ b/spydrnet/parsers/verilog/tests/test_verilogParser.py
@@ -1,13 +1,14 @@
 import unittest
 import spydrnet as sdn
-from spydrnet.parsers.verilog.parser import VerilogParser
+# from spydrnet.parsers.verilog.parser import VerilogParser
+from spydrnet import parsers
 import os
 
 class TestVerilogParser(unittest.TestCase):
     def test_simple_parse(self):
         directory = os.path.join(sdn.base_dir, "support_files", "verilog_netlists", "4bitadder.v.zip")
-        parser = VerilogParser.from_filename(directory)
-        netlist = parser.parse()
+        #parser = parse#VerilogParser.from_filename(directory)
+        netlist = parsers.parse(directory)
         print("hierarchy")
         self.simple_recursive_netlist_visualizer(netlist)
         print("Connectivity")

--- a/spydrnet/tests/test_verilog_to_edif.py
+++ b/spydrnet/tests/test_verilog_to_edif.py
@@ -1,0 +1,8 @@
+import unittest
+
+
+
+
+class TestVerilogToEdif(unittest.TestCase):
+
+    pass


### PR DESCRIPTION
The 1.5.0 branch does not support verilog parsing based on file name and will raise an exception. this patch aims to fix that.

verilog parsing is still available in the 1.5.0 release but a user must use an inconvenient and non standard import at the top of their file.