### PR TITLE
Create pins and wires during port and cable addition in definition 

### DIFF
--- a/spydrnet/ir/definition.py
+++ b/spydrnet/ir/definition.py
@@ -142,7 +142,7 @@ class Definition(FirstClassElement):
             return False
         return True
 
-    def create_port(self, name=None, properties=None, is_downto=None, is_scalar=None, lower_index=None, direction=None):
+    def create_port(self, name=None, properties=None, is_downto=None, is_scalar=None, lower_index=None, direction=None, pins=None):
         """Create a port, add it to the definition, and return that port.
 
         parameters
@@ -154,11 +154,13 @@ class Definition(FirstClassElement):
         is_scalar - (bool) set the scalar status. Return True if the item is a scalar False otherwise.
         lower_index - (int) get the value of the lower index of the array.
         direction - (Enum) Define the possible directions for a given port. (UNDEFINED, INOUT, IN, OUT)
-
+        pins - (int) Create number of pins in the newly created port
         """
         port = Port(name, properties, is_downto,
                     is_scalar, lower_index, direction)
         self.add_port(port)
+        if pins:
+            port.create_pins(pins)
         return port
 
     def add_port(self, port, position=None):
@@ -340,7 +342,7 @@ class Definition(FirstClassElement):
         global_callback._call_definition_remove_child(self, child)
         child._parent = None
 
-    def create_cable(self, name=None, properties=None, is_downto=None, is_scalar=None, lower_index=None):
+    def create_cable(self, name=None, properties=None, is_downto=None, is_scalar=None, lower_index=None, wires=None):
         """Create a cable, add it to the definition, and return the cable.
 
         parameters
@@ -351,9 +353,12 @@ class Definition(FirstClassElement):
         id_downto - (bool) set the downto status. Downto is False if the right index is higher than the left one, True otherwise
         is_scalar - (bool) set the scalar status. Return True if the item is a scalar False otherwise.
         lower_index - (int) get the value of the lower index of the array.
+        wires - (int) Create number of wires in the newly created cable
         """
         cable = Cable(name, properties, is_downto, is_scalar, lower_index)
         self.add_cable(cable)
+        if wires:
+            cable.create_wires(wires)
         return cable
 
     def add_cable(self, cable, position=None):

--- a/spydrnet/ir/tests/test_definition.py
+++ b/spydrnet/ir/tests/test_definition.py
@@ -27,7 +27,9 @@ class TestDefinition(unittest.TestCase):
         self.assertEqual(self.definition.ports, [port2, port1])
 
     def test_create_port(self):
-        port = self.definition.create_port()
+        port = self.definition.create_port("Port1", pins=2)
+        self.assertEqual(port.name, "Port1")
+        self.assertEqual(len(port.pins), 2)
         self.assertTrue(port in self.definition.ports)
         self.assertEqual(port.definition, self.definition)
 
@@ -72,7 +74,9 @@ class TestDefinition(unittest.TestCase):
         self.assertEqual(self.definition.cables, [cable2, cable1])
 
     def test_create_cable(self):
-        cable = self.definition.create_cable()
+        cable = self.definition.create_cable("cable1", wires=2)
+        self.assertEqual(cable.name, "cable1")
+        self.assertEqual(len(cable.wires), 2)
         self.assertTrue(cable in self.definition.cables)
         self.assertEqual(self.definition, cable.definition)
 


### PR DESCRIPTION
Added optional pins and wires parameters in `create_port` and `create_cable` methods of definition. 
It will create a defined number of pins or wires while creating a Port or cable. 

- Do not break existing functionality 
- Unit tests are updated