### PR TITLE
Enhancing verilog composer

### DIFF
--- a/spydrnet/composers/__init__.py
+++ b/spydrnet/composers/__init__.py
@@ -1,7 +1,7 @@
 import os
 
 
-def compose(netlist, filename):
+def compose(netlist, filename, definition_list=[], write_blackbox=True):
     """To compose a file into a netlist format"""
     extension = os.path.splitext(filename)[1]
     extension_lower = extension.lower()
@@ -13,7 +13,8 @@ def compose(netlist, filename):
         composer.run(netlist, filename)
     elif extension_lower in [".v", ".vh"]:
         from spydrnet.composers.verilog.composer import Composer
-        composer = Composer()
+        composer = Composer(definition_list, write_blackbox)
+        composer.run(netlist, file_out=filename)
         composer.run(netlist, file_out=filename)
     else:
         raise RuntimeError("Extension {} not recognized.".format(extension))

--- a/spydrnet/composers/__init__.py
+++ b/spydrnet/composers/__init__.py
@@ -15,6 +15,5 @@ def compose(netlist, filename, definition_list=[], write_blackbox=True):
         from spydrnet.composers.verilog.composer import Composer
         composer = Composer(definition_list, write_blackbox)
         composer.run(netlist, file_out=filename)
-        composer.run(netlist, file_out=filename)
     else:
         raise RuntimeError("Extension {} not recognized.".format(extension))

--- a/spydrnet/composers/verilog/composer.py
+++ b/spydrnet/composers/verilog/composer.py
@@ -13,7 +13,7 @@ class Composer:
         ----------
 
         definition_list - (list[str]) list of defintions to write
-        write_blackbox - (bool) Skips writing blckbox/ verilog primitives
+        write_blackbox - (bool) Skips writing black boxes/verilog primitives
         """
         self.file = None
         self.direction_string_map = dict()

--- a/spydrnet/composers/verilog/composer.py
+++ b/spydrnet/composers/verilog/composer.py
@@ -6,7 +6,15 @@ import spydrnet.parsers.verilog.verilog_tokens as vt
 
 class Composer:
 
-    def __init__(self):
+    def __init__(self, definition_list=None, write_blackbox=False):
+        """ Write a verilog netlist from SDN netlist
+
+        parameters
+        ----------
+
+        definition_list - (list[str]) list of defintions to write
+        write_blackbox - (bool) Skips writing blckbox/ verilog primitives
+        """
         self.file = None
         self.direction_string_map = dict()
         self.direction_string_map[Port.Direction.IN] = "input"
@@ -15,6 +23,9 @@ class Composer:
         self.direction_string_map[Port.Direction.UNDEFINED] = "/* undefined port direction */ inout"
         self.written = set()
         self.indent_count = 4  # set the indentation level for various components
+        self.write_blackbox = write_blackbox
+        self.definition_list = definition_list
+
 
     def run(self, ir, file_out="out.v"):
         self._open_file(file_out)
@@ -94,9 +105,14 @@ class Composer:
 
     def _write_module(self, definition):
         '''write the constraints then the module header then the module body'''
+        if self.definition_list:
+            if not (definition.name in self.definition_list):
+                return
         if definition.library.name == "SDN_VERILOG_ASSIGNMENT":
             return  # don't write assignment definitions
         if definition.library.name == "SDN.verilog_primitives":
+            if not self.write_blackbox:
+                return
             self.file.write(vt.CELL_DEFINE)
             self.file.write(vt.NEW_LINE)
         self._write_star_constraints(definition)

--- a/spydrnet/composers/verilog/tests/test_composer.py
+++ b/spydrnet/composers/verilog/tests/test_composer.py
@@ -73,3 +73,42 @@ class TestVerilogComposer(unittest.TestCase):
         print("processed",i,"errors", errors)
         
         assert errors == 0, "there were errors while parsing and composing files. Please see the output."
+
+    def test_definition_list_option(self):
+        for filename in glob.glob(os.path.join(
+                self.dir_of_verilog_netlists, "*4bitadder.v.zip")):
+            with tempfile.TemporaryDirectory() as tempdirectory:
+                netlist = parsers.parse(filename)
+                out_file = os.path.join(
+                    tempdirectory, os.path.basename(filename) + "-spydrnet.v")
+                composers.compose(netlist, out_file, definition_list=['adder'])
+
+                with open(out_file, "r") as fp:
+                    lines = fp.readlines()
+                    print(len(lines))
+                    m = list(filter(lambda x: x.startswith('module'), lines))
+            self.assertGreater(len(m), 0, "Adder module not written")
+            self.assertLess(len(m), 2, "Failed to write only definition_list")
+            return
+        raise AssertionError("Adder design not found " +
+                             "definition_list options not tested,")
+
+    def test_write_blackbox_option(self):
+        for filename in glob.glob(os.path.join(
+                self.dir_of_verilog_netlists, "*4bitadder.v.zip")):
+            with tempfile.TemporaryDirectory() as tempdirectory:
+                netlist = parsers.parse(filename)
+                out_file = os.path.join(
+                    tempdirectory, os.path.basename(filename) + "-spydrnet.v")
+                composers.compose(netlist, out_file, write_blackbox=False)
+
+                with open(out_file, "r") as fp:
+                    lines = fp.readlines()
+                    print(len(lines))
+                    m = list(filter(lambda x: x.startswith('module'), lines))
+            self.assertGreater(len(m), 0, "Adder module not written")
+            self.assertLess(len(m), 2, "Failed to write only definition_list" +
+                            "%s" % m)
+            return
+        raise AssertionError("definition_list options not test," +
+                             "Adder design not found")

--- a/spydrnet/composers/verilog/tests/test_composer_unit.py
+++ b/spydrnet/composers/verilog/tests/test_composer_unit.py
@@ -4,13 +4,14 @@
 #
 #Tests the verilog composers functions and output
 
+from collections import OrderedDict
 import unittest
 from unittest.case import expectedFailure
 import spydrnet as sdn
 from spydrnet.composers.verilog.composer import Composer
 
 class TestVerilogComposerUnit(unittest.TestCase):
-    
+
     class TestFile:
         '''represents a file (has a write function for the composer)
         can be used as a drop in replacement for the composer file.write function
@@ -20,7 +21,7 @@ class TestVerilogComposerUnit(unittest.TestCase):
 
         def write(self, text):
             self.written += text
-        
+
         def clear(self):
             self.written = ""
 
@@ -45,7 +46,7 @@ class TestVerilogComposerUnit(unittest.TestCase):
         composer = Composer()
         composer.file = self.TestFile()
         return composer
-    
+
     def initialize_netlist(self):
         netlist = sdn.Netlist()
         netlist.name = "test_netlist"
@@ -64,7 +65,7 @@ class TestVerilogComposerUnit(unittest.TestCase):
         return definition
 
     def initialize_instance_parameters(self, instance):
-        instance["VERILOG.Parameters"] = dict()
+        instance["VERILOG.Parameters"] = OrderedDict()
         instance["VERILOG.Parameters"]["key"] = "value"
         instance["VERILOG.Parameters"]["key2"] = "value2"
 
@@ -82,13 +83,13 @@ class TestVerilogComposerUnit(unittest.TestCase):
         single_bit_port.create_pin()
         single_bit_port.is_downto = True
         single_bit_port.name = "single_bit_port"
-        
+
         single_bit_cable = definition.create_cable()
         single_bit_cable.name = "single_bit_cable"
         single_bit_cable.is_downto = True
         single_bit_cable.create_wire()
 
-        
+
         multi_bit_port = ref_def.create_port()
         multi_bit_port.is_downto = True
         multi_bit_port.create_pins(4)
@@ -109,7 +110,7 @@ class TestVerilogComposerUnit(unittest.TestCase):
         multi_bit_cable.create_wires(4)
         multi_bit_cable.name = "multi_bit_cable"
         multi_bit_cable.is_downto = True
-        
+
 
         concatenated_port = ref_def.create_port()
         concatenated_port.create_pins(4)
@@ -122,7 +123,7 @@ class TestVerilogComposerUnit(unittest.TestCase):
             cable.is_downto = True
             cable.name = "cc_" + str(i)
             ccs.append(cable)
-    
+
 
         single_bit_cable.wires[0].connect_pin(instance.pins[single_bit_port.pins[0]])
 
@@ -135,9 +136,9 @@ class TestVerilogComposerUnit(unittest.TestCase):
             multi_bit_cable.wires[i].connect_pin(instance.pins[partial_port.pins[i]])
 
         single_bit_expected = "." + single_bit_port.name + "(" + single_bit_cable.name + ")"
-        
+
         multi_bit_expected = "." + multi_bit_port.name + "(" + multi_bit_cable.name + ")"
-        
+
         offset_expected = "." + multi_bit_port_offset.name + "(" + multi_bit_cable.name + ")"
 
         partial_expected = "." + partial_port.name + "(" + multi_bit_cable.name + "[1:0])"
@@ -160,13 +161,13 @@ class TestVerilogComposerUnit(unittest.TestCase):
     def test_write_brackets_single_bit(self):
         #def _write_brackets(self, bundle, low_index, high_index):
         composer = self.initialize_tests()
-        
+
         port = sdn.Port()
         cable = sdn.Cable()
 
         cable_name = "my_cable"
         port_name = "my_port"
-        
+
         port.name = port_name
         cable.name = cable_name
 
@@ -199,17 +200,17 @@ class TestVerilogComposerUnit(unittest.TestCase):
         assert composer.file.compare("")
         composer.file.clear()
         #none of these should write because they are all single bit.
-    
+
     def test_write_brackets_single_bit_offset(self):
         #def _write_brackets(self, bundle, low_index, high_index):
         composer = self.initialize_tests()
-        
+
         port = sdn.Port()
         cable = sdn.Cable()
 
         cable_name = "my_cable"
         port_name = "my_port"
-        
+
         port.name = port_name
         cable.name = cable_name
 
@@ -245,16 +246,16 @@ class TestVerilogComposerUnit(unittest.TestCase):
         assert composer.file.compare("")
         composer.file.clear()
         #none of these should write because they are all single bit.
-        
+
     def test_write_brackets_multi_bit(self):
         composer = self.initialize_tests()
-        
+
         port = sdn.Port()
         cable = sdn.Cable()
 
         cable_name = "my_cable"
         port_name = "my_port"
-        
+
         port.name = port_name
         cable.name = cable_name
 
@@ -300,17 +301,17 @@ class TestVerilogComposerUnit(unittest.TestCase):
         composer._write_brackets(cable, 1, 2)
         assert composer.file.compare("[2:1]")
         composer.file.clear()
-        
+
 
     def test_write_brackets_multi_bit_offset(self):
         composer = self.initialize_tests()
-        
+
         port = sdn.Port()
         cable = sdn.Cable()
 
         cable_name = "my_cable"
         port_name = "my_port"
-        
+
         port.name = port_name
         cable.name = cable_name
 
@@ -363,7 +364,7 @@ class TestVerilogComposerUnit(unittest.TestCase):
         pass #we should add some tests to test out of bounds on the brackets.
 
     def test_write_brackets_defining(self):
-        
+
         composer = self.initialize_tests()
 
         def initialize_bundle(bundle, offset, width):
@@ -391,7 +392,7 @@ class TestVerilogComposerUnit(unittest.TestCase):
         composer._write_brackets_defining(b3)
         assert composer.file.compare("[3:0]")
         composer.file.clear()
-        
+
         composer._write_brackets_defining(b4)
         assert composer.file.compare("[7:4]")
         composer.file.clear()
@@ -405,17 +406,17 @@ class TestVerilogComposerUnit(unittest.TestCase):
             composer._write_name(o)
             assert composer.file.compare(n)
             composer.file.clear()
-    
+
     @unittest.expectedFailure
     def test_write_none_name(self):
         composer = self.initialize_tests()
-        o = sdn.Cable() 
+        o = sdn.Cable()
         composer._write_name(o)
 
     @unittest.expectedFailure
     def test_write_invalid_name(self):
         composer = self.initialize_tests()
-        o = sdn.Cable() 
+        o = sdn.Cable()
         o.name = "\\escaped_no_space"
         composer._write_name(o)
 
@@ -435,11 +436,11 @@ class TestVerilogComposerUnit(unittest.TestCase):
         composer._write_instance_port(instance, single_bit_port)
         assert composer.file.compare(single_bit_expected)
         composer.file.clear()
-        
+
         composer._write_instance_port(instance, multi_bit_port)
         assert composer.file.compare(multi_bit_expected)
         composer.file.clear()
-        
+
         composer._write_instance_port(instance, multi_bit_port_offset)
         assert composer.file.compare(offset_expected)
         composer.file.clear()
@@ -529,8 +530,8 @@ class TestVerilogComposerUnit(unittest.TestCase):
     def test_write_module_header(self):
         composer = self.initialize_tests()
         definition = self.initialize_definition()
-        
-        definition["VERILOG.Parameters"] = dict()
+
+        definition["VERILOG.Parameters"] = OrderedDict()
 
         definition["VERILOG.Parameters"]["key"] = "value"
         definition["VERILOG.Parameters"]["no_default"] = None
@@ -604,7 +605,7 @@ class TestVerilogComposerUnit(unittest.TestCase):
         port_disconnect = definition.create_port("disconnected")
         port_disconnect.direction = sdn.Port.Direction.INOUT
         port_disconnect.create_pin()
-    
+
         composer._write_module_header_port(port_disconnect)
         assert composer.file.compare(port_disconnect.name)
         composer.file.clear()
@@ -618,7 +619,7 @@ class TestVerilogComposerUnit(unittest.TestCase):
 
         cable = definition.create_cable(name = "test_cable", is_downto = True)
         cable.create_wires(4)
-        
+
         composer._write_module_body_cable(cable)
         assert composer.file.compare("wire [3:0]" + cable.name + ";\n")
 

--- a/spydrnet/parsers/verilog/parser.py
+++ b/spydrnet/parsers/verilog/parser.py
@@ -680,7 +680,7 @@ class VerilogParser:
 
     def parse_defparam_parameters(self):
         '''parse a defparam structure and add the parameters to the associated instance
-        
+
         this looks like:
 
         defparam \\avs_s1_readdata[12]~output .bus_hold = "false"; //single backslash to escape name
@@ -710,7 +710,7 @@ class VerilogParser:
         token = self.next_token()
         assert token == vt.SEMI_COLON, self.error_string(vt.SEMI_COLON, "to end the defparam statement", token)
         self.set_instance_parameters(instance, params)
-        
+
 
     def parse_parameter_mapping(self):
         params = dict()
@@ -776,7 +776,6 @@ class VerilogParser:
             vt.DOT, "to start a port mapping instance", token)
 
         token = self.next_token()
-        print(token)
         assert vt.is_valid_identifier(token), self.error_string(
             "valid port identifier", "for port in instantiation port map", token)
         port_name = token
@@ -834,7 +833,7 @@ class VerilogParser:
     def parse_variable_instantiation(self):
         '''parse the cable name and its indicies if any
         if we are in Intel land then 2 other things can happen.
-        the "cable" is a constant, 
+        the "cable" is a constant,
             attach it to the \\<const0> or \\<const1> cable.
         the cable is inverted,
             create a new cable and an inverter block similar to the assign but with an inversion in the block


### PR DESCRIPTION
Enhancing Verilog composer functionality, adding the following parameters
`definition_list` : Specify a list of definitions to compose, default it writes everything
`write_blackbox` : bool, to skip writing black-box

I added tests also let me know what you think. 