### PR TITLE
Initial support for case insensitive naming

### DIFF
--- a/spydrnet/global_state/global_flags.py
+++ b/spydrnet/global_state/global_flags.py
@@ -1,0 +1,17 @@
+
+_global_flags = {
+    'use_case_sensitive_naming' : True
+}
+
+def _get_global_flag(name):
+    return _global_flags[name]
+
+def _set_global_flag(name, value):
+    global _global_flags
+    _global_flags[name] = value
+
+def use_case_sensitive_naming():
+    return _get_global_flag('use_case_sensitive_naming')
+
+def set_use_case_sensitive_naming(use_case_sensitive_naming):
+    _set_global_flag('use_case_sensitive_naming', use_case_sensitive_naming)

--- a/spydrnet/parsers/__init__.py
+++ b/spydrnet/parsers/__init__.py
@@ -8,7 +8,7 @@ Init for Spydrnet. The functions below can be called directly
 """
 
 
-def parse(filename):
+def parse(filename, **kwArgs):
     """
     The parse function is able to parse an EDIF (.edf) file, a Verilog file (.v), or an EBLIF file (.eblif).
 
@@ -50,15 +50,15 @@ def parse(filename):
                 zip.extract(basename_less_final_extension, tempdirname)
                 filename = os.path.join(
                     tempdirname, basename_less_final_extension)
-                return _parse(filename)
-    return _parse(filename)
+                return _parse(filename, **kwArgs)
+    return _parse(filename, **kwArgs)
 
 
-def _parse(filename):
+def _parse(filename, **kwArgs):
     extension = get_lowercase_extension(filename)
     if extension in [".edf", ".edif", ".edn"]:
         from spydrnet.parsers.edif.parser import EdifParser
-        parser = EdifParser.from_filename(filename)
+        parser = EdifParser.from_filename(filename, **kwArgs)
     elif extension in [".v", ".vh"]:
         from spydrnet.parsers.verilog.parser import VerilogParser
         parser = VerilogParser.from_filename(filename)

--- a/spydrnet/parsers/edif/parser.py
+++ b/spydrnet/parsers/edif/parser.py
@@ -2,6 +2,7 @@ from spydrnet.parsers.edif.tokenizer import EdifTokenizer
 from spydrnet.parsers.edif.edif_tokens import *
 from spydrnet.ir import Netlist, Library, Definition, Port, Cable, Instance
 from spydrnet.plugins import namespace_manager
+from spydrnet.global_state import global_flags
 
 from functools import reduce
 import re
@@ -15,23 +16,24 @@ class EdifParser:
         return result
 
     @staticmethod
-    def from_filename(filename):
-        parser = EdifParser()
+    def from_filename(filename, **kwArgs):
+        parser = EdifParser(**kwArgs)
         parser.filename = filename
         return parser
 
     @staticmethod
-    def from_file_handle(file_handle):
-        parser = EdifParser()
+    def from_file_handle(file_handle, **kwArgs):
+        parser = EdifParser(**kwArgs)
         parser.file_handle = file_handle
         return parser
 
-    def __init__(self):
+    def __init__(self, **kwArgs):
         self.edif_identifier_namespace = dict() # class -> object -> subclass -> identifier -> object
         self.filename = None
         self.file_handle = None
         self.elements = list()
         self.tokenizer = None
+        global_flags.set_use_case_sensitive_naming('case_sensitive_naming' not in kwArgs or kwArgs['case_sensitive_naming'])
 
     def parse(self):
         self.initialize_tokenizer()

--- a/spydrnet/plugins/namespace_manager/edif_namespace.py
+++ b/spydrnet/plugins/namespace_manager/edif_namespace.py
@@ -2,6 +2,7 @@ from spydrnet.plugins.namespace_manager.default_namespace import DefaultNamespac
 from spydrnet.ir import Netlist, Library, Definition
 import re
 from spydrnet.plugins.namespace_manager.default_namespace import DefaultNamespace
+from spydrnet.global_state import global_flags
 
 
 class EdifNamespace(DefaultNamespace):
@@ -137,8 +138,9 @@ class EdifNamespace(DefaultNamespace):
                 namespace = self.edif_namespaces[element_type]
                 value_lower = value.lower()
                 if value_lower in namespace:
-                    if namespace[value_lower] != element:
-                        return False
+                    if global_flags.use_case_sensitive_naming() or value_lower != element.name.lower():
+                        if namespace[value_lower] != element:
+                            return False
         return True
 
     def update(self, element, key, value):


### PR DESCRIPTION
This is in regards to #116, I had a similar issue where there were components with the same name, but different casing and so I got an error. This adds a possible way to have a flag to use case insensitive name matching. I am not sure if this implementation is something the project would be willing to accept, it does work for me. I am definitely willing to work on a different implementation to get this feature included.