### PR TITLE
[Bugfix] constant net name 

### DIFF
--- a/spydrnet/parsers/verilog/parser.py
+++ b/spydrnet/parsers/verilog/parser.py
@@ -954,7 +954,7 @@ class VerilogParser:
             assert token[1] == vt.SINGLE_QUOTE, self.error_string(vt.SINGLE_QUOTE, "in the constant", token)
             assert token[2] == 'b', self.error_string('b', "in the constant", token)
             assert token[3] in ["0", "1", "x", "X", "z", "Z"], self.error_string("one of 0, 1, x, X, z, Z", "represent the constant value after '", token)
-            name = "\\<const" + token[2] + "> "
+            name = "\\<const" + token[3] + "> "
         elif vt.is_numeric(token[0]):
             assert False, self.error_string("single bit constant", "multibit constants not supported", token)
         else:

--- a/spydrnet/parsers/verilog/tests/test_verilogParser.py
+++ b/spydrnet/parsers/verilog/tests/test_verilogParser.py
@@ -1385,6 +1385,31 @@ class TestVerilogParser(unittest.TestCase):
                 w22 = expected2[i][j]
                 assert w21 == w22, "the wires are not the same or not in the same order"
 
+    def test_constant_parsing(self):
+        """
+        Tests multiple wire decalaration on the same line in verilog
+        """
+        parser = VerilogParser()
+
+        # Check constant 0 net declaration
+        tokens = ("1'b0", vt.SEMI_COLON)
+        tokenizer = self.TestTokenizer(tokens)
+        parser = VerilogParser()
+        parser.tokenizer = tokenizer
+
+        parser.current_definition = sdn.Definition()
+        cable, _, _ = parser.parse_variable_instantiation()
+        self.assertEqual(cable.name, "\\<const0> ", "Check const wire name")
+
+        # Check constant 1 net declaration
+        tokens = ("1'b1", vt.SEMI_COLON)
+        tokenizer = self.TestTokenizer(tokens)
+        parser = VerilogParser()
+        parser.tokenizer = tokenizer
+
+        parser.current_definition = sdn.Definition()
+        cable, _, _ = parser.parse_variable_instantiation()
+        self.assertEqual(cable.name, "\\<const1> ", "Check const wire name")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`SpyDrNet` currently supports single-bit constant declaration. 
However during parsing it names `1'b1` and `1'b0` both as  `\\<constb> `
This PR fixes the that and creates distinct net  `\\<const1> ` and  `\\<const0> ` respectively.
Added unit test also