### PR TITLE
[verilog] Fixed parser not properly handling empty instance port list

### DIFF
--- a/spydrnet/parsers/verilog/parser.py
+++ b/spydrnet/parsers/verilog/parser.py
@@ -905,6 +905,14 @@ class VerilogParser:
                 vt.OPEN_PARENTHESIS, "to encapsulate cable name in port mapping", token)
             
             index = 0
+
+            # There may be no mapped wires at all. It may be empty or filled with whitespace
+            token = self.peek_token()
+
+            if token == vt.CLOSE_PARENTHESIS:
+                # Consume the token, we're going to skip the loop
+                token = self.next_token()
+
             while (token != vt.CLOSE_PARENTHESIS):
                 token = self.peek_token()
 


### PR DESCRIPTION
The Verilog parser currently crashes when instantiating modules with an empty port list, of the form:
```verilog
MyModule crasher ();
```

This fixes this minor issue and adds tests for the situation.