### PR TITLE
SpyDrNet 1.12.2

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,3 +1,10 @@
+SpyDrNet 1.12.2
+----------------
+April 18, 2023
+
+Bug fix for Verilog parser for partially connected ports being misaligned and fixed primitive name with a space at the end.
+Changed some of the os.path to pathlib to conform to updated coding standards
+
 SpyDrNet 1.12.1
 ----------------
 February 2, 2023

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -1,6 +1,6 @@
 .. _sec:examples:
 
-.. _sphinx_glr_auto_examples:
+.. _sphx_glr_auto_examples:
 
 Examples
 ========

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -1,5 +1,7 @@
 .. _sec:examples:
 
+.. _sphinx_glr_auto_examples:
+
 Examples
 ========
 


### PR DESCRIPTION
SpyDrNet 1.12.2
----------------
April 18, 2023

Bug fix for Verilog parser for partially connected ports being misaligned and fixed primitive name with a space at the end.
Changed some of the os.path to pathlib to conform to updated coding standards