### PR TITLE
Handle params in module's body and multi-entry assigns in Verilog parser 

### DIFF
--- a/spydrnet/parsers/verilog/parser.py
+++ b/spydrnet/parsers/verilog/parser.py
@@ -1177,11 +1177,7 @@ class VerilogParser:
             token = self.next_token()
             while(token != vt.CLOSE_BRACE):
                 cable_lr_list = self.parse_variable_instantiation()
-                assert len(cable_lr_list) == 1, self.error_string(
-                    'one entity declaration', "assign statement", token
-                )
-                cable, left, right = cable_lr_list[0]
-                raw_cables_list.append((cable, left, right))
+                raw_cables_list.extend(cable_lr_list)
                 token = self.next_token()
         else:
             cable_lr_list = self.parse_variable_instantiation()


### PR DESCRIPTION
I work with YOSYS output netlists a lot, they may have non-trivial assignments that are must to parse.
Thought that some changes may be useful.
Example:
assign \biquadi.ma12out_SUM_Q_I1_LUT_I3_Q_LUT_Q_1_I1_LUT_Q_I3_LUT_I2_Q_LUT_Q_I3 [1:0] = { \biquadi.ma11out_SUM_Q_I1_LUT_I3_Q_LUT_Q_10_I0 [1], \biquadi.ma11out_SUM_Q_I1_LUT_I3_Q_LUT_Q_9_I2_LUT_Q_I1_LUT_I1_1_Q [1] };
assign \biquadi.mb10out_SUM_Q_8_I1 [13:3] = 11'b00000000000;