### PR TITLE
Fix version string on non-master branch to comply with PEP440

### DIFF
--- a/spydrnet/release.py
+++ b/spydrnet/release.py
@@ -122,7 +122,6 @@ def update_versionfile():
         git_describe_output = git_subprocess.stdout.read().decode()
 
         git_version = git_describe_output.strip()
-        print(git_version)
         if git_version.startswith("v"):
             # Mimic setuptools_scm behavior
             # See https://stackoverflow.com/questions/35522047/pep440-compliant-and-git-describe-info-available-from-deployed-package

--- a/spydrnet/release.py
+++ b/spydrnet/release.py
@@ -122,7 +122,13 @@ def update_versionfile():
         git_describe_output = git_subprocess.stdout.read().decode()
 
         git_version = git_describe_output.strip()
+        print(git_version)
         if git_version.startswith("v"):
+            # Mimic setuptools_scm behavior
+            # See https://stackoverflow.com/questions/35522047/pep440-compliant-and-git-describe-info-available-from-deployed-package
+            dash_idx = git_version.find("-")
+            git_version = git_version[:dash_idx] + "+g" + git_version[dash_idx + 1 :]
+
             version_file = Path(directory, "VERSION")
             with open(version_file, "w") as fh:
                 fh.write(git_version + "\n")


### PR DESCRIPTION
Changes version string.  Fixes #218 

Example old version string: `1.13.0-16-g2bf4441`
Example new version string: `1.13.0+g16-g2bf4441`