### PR TITLE
is_downto flag fix for big-endian bundle declaration

### DIFF
--- a/spydrnet/composers/verilog/composer.py
+++ b/spydrnet/composers/verilog/composer.py
@@ -569,7 +569,7 @@ class Composer:
         assert name is not None, self._error_string("name of o is not set", o)
         name = self._fix_name(name)
         self.file.write(name)
-    
+
     def _rename_constant(self, cable):
         """
         \<const0> and \<const1> wires without a driver should be renamed to 1'b0 and 1'b1
@@ -700,7 +700,12 @@ class Composer:
             ), self._error_string(
                 "attempted to write an index out of bounds: " + str(high_index), bundle
             )
-            self.file.write("[" + str(high_index) + ":" + str(low_index) + "]")
+            if bundle.is_downto:
+                self.file.write(
+                    "[" + str(high_index) + ":" + str(low_index) + "]")
+            else:
+                self.file.write(
+                    "[" + str(low_index) + ":" + str(high_index) + "]")
 
     ###############################################################################
     # helper functions for composing

--- a/spydrnet/composers/verilog/composer.py
+++ b/spydrnet/composers/verilog/composer.py
@@ -619,9 +619,14 @@ class Composer:
             return  # no need to write because this is assumed
 
         self.file.write(vt.OPEN_BRACKET)
-        self.file.write(str(bundle.lower_index + width - 1))
-        self.file.write(vt.COLON)
-        self.file.write(str(bundle.lower_index))
+        if bundle.is_downto:
+            self.file.write(str(bundle.lower_index + width - 1))
+            self.file.write(vt.COLON)
+            self.file.write(str(bundle.lower_index))
+        else:
+            self.file.write(str(bundle.lower_index))
+            self.file.write(vt.COLON)
+            self.file.write(str(bundle.lower_index + width - 1))
         self.file.write(vt.CLOSE_BRACKET)
 
     def _write_brackets(self, bundle, low_index, high_index):

--- a/spydrnet/composers/verilog/composer.py
+++ b/spydrnet/composers/verilog/composer.py
@@ -663,7 +663,12 @@ class Composer:
         elif (low_index == lower_bundle and high_index == upper_bundle) or (
             low_index is None and high_index is None
         ):
-            self.file.write("[" + str(high_index) + ":" + str(low_index) + "]")
+            if bundle.is_downto:
+                self.file.write(
+                    "[" + str(high_index) + ":" + str(low_index) + "]")
+            else:
+                self.file.write(
+                    "[" + str(low_index) + ":" + str(high_index) + "]")
             return
         elif low_index == high_index or low_index is None or high_index is None:
             index = low_index

--- a/spydrnet/composers/verilog/composer.py
+++ b/spydrnet/composers/verilog/composer.py
@@ -270,7 +270,9 @@ class Composer:
             if w is not None:
                 index = self._index_of_wire_in_cable(w)
                 if w.cable.name == previous_cable.name:
-                    if index == (previous_index - 1):
+                    if (index == (previous_index - 1)) and w.cable.is_downto:
+                        previous_index = index
+                    elif (index == (previous_index + 1)) and not w.cable.is_downto:
                         previous_index = index
                     else:
                         # write the previous and save new stuff

--- a/spydrnet/parsers/verilog/parser.py
+++ b/spydrnet/parsers/verilog/parser.py
@@ -1577,6 +1577,7 @@ class VerilogParser:
             cable.lower_index = in_lower
             cable_lower = cable.lower_index
             cable_upper = cable.lower_index + len(cable.wires) - 1
+            cable.is_downto = right_index <= left_index
 
         if in_upper is not None and in_lower is not None:
             if in_lower < cable_lower:
@@ -1683,6 +1684,7 @@ class VerilogParser:
             port.lower_index = in_lower
             port_lower = port.lower_index
             port_upper = port.lower_index + len(port.pins) - 1
+            port.is_downto = right_index <= left_index
 
         if in_upper is not None and in_lower is not None:
             # to prevent unneccessary pins being added, check to see if port

--- a/tests/spydrnet/composers/verilog/tests/test_composer_unit.py
+++ b/tests/spydrnet/composers/verilog/tests/test_composer_unit.py
@@ -355,6 +355,14 @@ class TestVerilogComposerUnit(unittest.TestCase):
         assert composer.file.compare("[1:2]")
         composer.file.clear()
 
+        composer._write_brackets(cable, 0, 3)
+        assert composer.file.compare("[0:3]")
+        composer.file.clear()
+
+        composer._write_brackets(cable, 3, 3)
+        assert composer.file.compare("[3]")
+        composer.file.clear()
+
     def test_write_brackets_multi_bit_offset(self):
         composer = self.initialize_tests()
 
@@ -750,4 +758,4 @@ class TestVerilogComposerUnit(unittest.TestCase):
 
         composer._write_module_body_cables(definition)
         self.assertTrue(composer.file.compare("wire " + c1.name + " ;\n\n"))
-        
+

--- a/tests/spydrnet/composers/verilog/tests/test_composer_unit.py
+++ b/tests/spydrnet/composers/verilog/tests/test_composer_unit.py
@@ -349,6 +349,12 @@ class TestVerilogComposerUnit(unittest.TestCase):
         assert composer.file.compare("[2:1]")
         composer.file.clear()
 
+        # big endian declaration
+        cable.is_downto = False
+        composer._write_brackets(cable, 1, 2)
+        assert composer.file.compare("[1:2]")
+        composer.file.clear()
+
     def test_write_brackets_multi_bit_offset(self):
         composer = self.initialize_tests()
 
@@ -412,12 +418,12 @@ class TestVerilogComposerUnit(unittest.TestCase):
     def test_write_brackets_defining(self):
         composer = self.initialize_tests()
 
-        def initialize_bundle(bundle, offset, width):
+        def initialize_bundle(bundle, offset, width, is_downto=True):
             if isinstance(bundle, sdn.Port):
                 bundle.create_pins(width)
             else:  # it's a cable
                 bundle.create_wires(width)
-            bundle.is_downto = True
+            bundle.is_downto = is_downto
             bundle.lower_index = offset
             return bundle
 
@@ -425,6 +431,8 @@ class TestVerilogComposerUnit(unittest.TestCase):
         b2 = initialize_bundle(sdn.Cable(), 4, 1)
         b3 = initialize_bundle(sdn.Port(), 0, 4)
         b4 = initialize_bundle(sdn.Cable(), 4, 4)
+        b5 = initialize_bundle(sdn.Cable(), 0, 3, False)
+        b6 = initialize_bundle(sdn.Cable(), 4, 8, False)
 
         composer._write_brackets_defining(b1)
         assert composer.file.compare("")
@@ -440,6 +448,14 @@ class TestVerilogComposerUnit(unittest.TestCase):
 
         composer._write_brackets_defining(b4)
         assert composer.file.compare("[7:4]")
+        composer.file.clear()
+
+        composer._write_brackets_defining(b5)
+        assert composer.file.compare("[0:2]")
+        composer.file.clear()
+
+        composer._write_brackets_defining(b6)
+        assert composer.file.compare("[4:11]")
         composer.file.clear()
 
     def test_write_name(self):


### PR DESCRIPTION
Currently `is_dowto` property on cable and port for big-endian declaration only works when Verilog is defined in variant1 format and fails for Variant2 format this PR fixes this.

**Variant1**
```
module test_definition(input [0:1] upto);
endmodule
```
**Variant2**
```
module test_definition(upto);
    input [0:1] upto;
endmodule
```