### PR TITLE
Added default_nettype as a verilog token

### DIFF
--- a/spydrnet/parsers/verilog/parser.py
+++ b/spydrnet/parsers/verilog/parser.py
@@ -244,6 +244,8 @@ class VerilogParser:
             elif token.split(maxsplit=1)[0] == vt.TIMESCALE:
                 token = self.next_token()
                 time_scale = token.split(maxsplit=1)[1]
+            elif token.split(maxsplit=1)[0] == vt.DEFUALT_NETTYPE:
+                token = self.next_token()
             else:
                 pass
                 assert False, self.error_string(

--- a/spydrnet/parsers/verilog/verilog_tokens.py
+++ b/spydrnet/parsers/verilog/verilog_tokens.py
@@ -111,6 +111,7 @@ TRI1 = "tri1"
 DEFPARAM = "defparam"
 CONST0 = "\\<const0>"
 CONST1 = "\\<const1>"
+DEFUALT_NETTYPE = "`default_nettype"
 
 # SET OF ALL THINGS THAT WILL END AN IDENTIFIER IF THEY ARE NOT ESCAPED.
 # elif ch in {'(', ')', '.', ',', ';', '[', ']', ':', "{", "}", "*", "#", "`"}:


### PR DESCRIPTION
In Verilog functional simulation the default_nettype directive is added to infer undefined signal nets as wire `default_nettype wire` or to prevent inferring nettype for undefined wires `default_nettype none`.
I am adding this token to prevent error while parsing verilog file when this directive exist. 